### PR TITLE
Added "require" to exports for react-native-web imports to compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
     }
   },
   "peerDependencies": {


### PR DESCRIPTION
What I submitted in this PR: https://github.com/ndom91/react-timezone-select/pull/144

---

### Description

Lovely package. I had to add this simple one-liner to it in order to use it from a React-Native-Web (RNW) application I'm working on. I probably would have gotten by with just using `npx patch-package react-timezone-select` but `patch-package` is ignoring my change to `package.json`

### Linked Issues

Didn't create one, just went and requested this change.

### Additional context

A bit of context, my vanilla RNW `tsconfig.json` file:

```
{
  "extends": "@react-native/typescript-config/tsconfig.json",
  "exclude": ["node_modules"],
  "compilerOptions": {
    "typeRoots": ["./src/types"],
    "isolatedModules": false,
    "allowImportingTsExtensions": false,
    "paths": {
      "react": ["./node_modules/@types/react"],
      "@shared/*": ["../shared/*"]
    },
    "lib": ["es6", "dom"] // ✅ Ensures TypeScript recognizes `document`
  }
}
```

If you need more context, let me know.
